### PR TITLE
Add configurable villager assignment actions

### DIFF
--- a/constants.yaml
+++ b/constants.yaml
@@ -11,6 +11,10 @@ actions:
   train_villager:
     food_cost: 50
     train_time: 25   # seconds
+  assign_food:
+    resource: food
+  assign_wood:
+    resource: wood
   build_house:
     wood_cost: 25
     build_time: 20


### PR DESCRIPTION
## Summary
- expose villager food and wood assignment actions in the balance constants
- let the simulator consume the configured resource for assign actions and emit events

## Testing
- python -m compileall simulator.py

------
https://chatgpt.com/codex/tasks/task_e_68e8cb2b8b28832f8215cf937d430222